### PR TITLE
Fix: Ensure jQuery is loaded before dependent scripts in seedbox_ui

### DIFF
--- a/app/seedbox_ui/templates/seedbox_ui/index.html
+++ b/app/seedbox_ui/templates/seedbox_ui/index.html
@@ -329,6 +329,8 @@
 {# Inclusion des Modals #}
 {% include "seedbox_ui/_modals.html" %}
 
+    <!-- jQuery -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <!-- Bootstrap Bundle JS (Popper.js included) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>


### PR DESCRIPTION
Resolved the 'Uncaught ReferenceError: $ is not defined' error that occurred in `seedbox_ui_modals.js` on pages related to the `seedbox_ui` blueprint.

The error was caused by `seedbox_ui_modals.js` (which uses jQuery) being loaded before jQuery itself.

Modified `app/seedbox_ui/templates/seedbox_ui/index.html` to include the jQuery script tag before Bootstrap's JS bundle and any custom scripts like `seedbox_ui_modals.js` that depend on jQuery.