### PR TITLE
Fix(plex): Remove condition disabling archive button for shows

### DIFF
--- a/app/plex_editor/templates/plex_editor/library.html
+++ b/app/plex_editor/templates/plex_editor/library.html
@@ -426,7 +426,7 @@
                                             data-bs-toggle="modal" data-bs-target="#archiveShowModal"
                                             data-rating-key="{{ item.ratingKey }}" data-title="{{ item.title|e }}"
                                             data-leaf-count="{{ item.leafCount }}" data-viewed-leaf-count="{{ item.viewedLeafCount }}"
-                                            {% if item.leafCount != item.viewedLeafCount %}disabled{% endif %} title="Archiver la série complète">
+                                            title="Archiver la série complète">
                                         <i class="fas fa-tv"></i> <i class="fas fa-archive"></i>
                                     </button>
                                     {% endif %}


### PR DESCRIPTION
The archive button for TV shows was previously disabled if the number of viewed episodes (viewedLeafCount) did not match the total number of episodes (leafCount).

This change removes the Jinja2 condition responsible for adding the 'disabled' attribute in the `library.html` template. The button will now always be active, allowing users to open the archive modal regardless of the viewed status. The modal itself still displays the viewed/total episode counts, so the user can make an informed decision before archiving.