### PR TITLE
feat: Implémentation du téléchargeur final et du mapping

### DIFF
--- a/app/search_ui/templates/search_ui/search.html
+++ b/app/search_ui/templates/search_ui/search.html
@@ -73,6 +73,8 @@
                                     <a href="#" class="btn btn-sm btn-success download-and-map-btn"
                                        data-release-title="{{ result.title|e }}"
                                        data-download-link="{{ result.downloadUrl }}"
+                                       data-guid="{{ result.guid }}" {# Ajouté #}
+                                       data-indexer-id="{{ result.indexerId }}" {# Ajouté #}
                                        data-parsed-title="{{ result.status_info.parsed_title|e }}">
                                         <i class="fas fa-download"></i> & Mapper
                                     </a>

--- a/app/static/js/search_actions.js
+++ b/app/static/js/search_actions.js
@@ -12,11 +12,19 @@ $(document).ready(function() {
         // Stocker les données sur la modale pour les retrouver plus tard
         const releaseTitleToStore = $(this).data('release-title');
         const downloadLinkToStore = $(this).data('download-link');
-        console.log("[Handler 1] Storing on modal: releaseTitle =", releaseTitleToStore, ", downloadLink =", downloadLinkToStore);
+        const guidToStore = $(this).data('guid');
+        const indexerIdToStore = $(this).data('indexer-id');
+
+        console.log("[Handler 1] Storing on modal: releaseTitle =", releaseTitleToStore, ", downloadLink =", downloadLinkToStore, ", guid =", guidToStore, ", indexerId =", indexerIdToStore);
         modalElement.data('releaseTitle', releaseTitleToStore);
         modalElement.data('downloadLink', downloadLinkToStore);
+        modalElement.data('guid', guidToStore);
+        modalElement.data('indexerId', indexerIdToStore);
         // Verification log immediately after storing
-        console.log("[Handler 1] Data stored: releaseTitle on modal is now", modalElement.data('releaseTitle'), ", downloadLink on modal is now", modalElement.data('downloadLink'));
+        console.log("[Handler 1] Data stored: releaseTitle on modal is now", modalElement.data('releaseTitle'),
+                    ", downloadLink on modal is now", modalElement.data('downloadLink'),
+                    ", guid on modal is now", modalElement.data('guid'),
+                    ", indexerId on modal is now", modalElement.data('indexerId'));
         
         // Pré-remplir le champ de recherche
         modalElement.find('#sonarrRadarrQuery').val($(this).data('parsed-title') || '');
@@ -100,17 +108,25 @@ $(document).ready(function() {
         const modal = $('#sonarrRadarrSearchModal');
         const retrievedReleaseTitle = modal.data('releaseTitle');
         const retrievedDownloadLink = modal.data('downloadLink');
+        const retrievedGuid = modal.data('guid');
+        const retrievedIndexerId = modal.data('indexerId');
+
         // Keeping this log for now as it confirms modal data, can be removed later if desired.
-        console.log("[Handler 3] Retrieving from modal: releaseTitle =", retrievedReleaseTitle, ", downloadLink =", retrievedDownloadLink);
+        console.log("[Handler 3] Retrieving from modal: releaseTitle =", retrievedReleaseTitle,
+                    ", downloadLink =", retrievedDownloadLink,
+                    ", guid =", retrievedGuid,
+                    ", indexerId =", retrievedIndexerId);
 
         // Use the retrieved values for the check and subsequent operations
         const releaseTitle = retrievedReleaseTitle;
         const downloadLink = retrievedDownloadLink;
+        const guid = retrievedGuid;
+        const indexerId = retrievedIndexerId;
 
-        if (!mediaId || !mediaType || !releaseTitle || !downloadLink) {
-            alert("Erreur critique : une information essentielle est manquante.");
+        if (!mediaId || !mediaType || !releaseTitle || !downloadLink || !guid || !indexerId) {
+            alert("Erreur critique : une information essentielle est manquante (mediaId, mediaType, releaseTitle, downloadLink, guid, ou indexerId).");
             // Simplified error log
-            console.error("[Handler 3] Missing data check failed:", { mediaId, mediaType, releaseTitle, downloadLink });
+            console.error("[Handler 3] Missing data check failed:", { mediaId, mediaType, releaseTitle, downloadLink, guid, indexerId });
             return;
         }
     
@@ -123,6 +139,8 @@ $(document).ready(function() {
             body: JSON.stringify({
                 releaseName: releaseTitle,
                 downloadLink: downloadLink,
+                indexerId: indexerId, // Ajouté
+                guid: guid,           // Ajouté
                 instanceType: mediaType,
                 mediaId: mediaId
             })


### PR DESCRIPTION
Implémente la fonctionnalité de téléchargement de torrent et de mapping automatique pour la page de recherche.

Points clés :
- Ajout de la configuration pour YGG (YGG_INDEXER_ID, YGG_BASE_URL, etc.).
- Mise à jour de `search_actions.js` pour récupérer et transmettre `guid` et `indexerId` lors du clic sur "& Mapper".
- Création/modification des routes backend dans `search_ui/routes.py`:
    - `/download_torrent_proxy`: Sert de proxy pour télécharger les fichiers .torrent, avec une logique spéciale pour YGG (utilisation de cookie et construction d'URL directe via GUID) et une logique standard pour les autres indexers.
    - `/download-and-map`: Automatise le téléchargement du .torrent (en utilisant la même logique que le proxy), l'envoi à rTorrent et le mapping avec Sonarr/Radarr.
- Mise à jour de `search.html` pour :
    - Faire pointer le bouton "Télécharger" vers la route `/download_torrent_proxy`.
    - Assurer que le bouton "& Mapper" transmet `guid` et `indexerId` via les attributs data.