### PR TITLE
feat: Synchronize monitoring switches in series management modal

### DIFF
--- a/app/plex_editor/templates/plex_editor/_series_management_modal_content.html
+++ b/app/plex_editor/templates/plex_editor/_series_management_modal_content.html
@@ -16,11 +16,11 @@
     </div>
     {% if series.sonarr_series_id %}
     <div class="form-check form-switch fs-5">
-        <input class="form-check-input series-global-monitor-toggle" type="checkbox" role="switch"
-               id="monitor-series-{{ series.ratingKey }}"
+        <input class="form-check-input" type="checkbox" role="switch"
+               id="series-monitor-toggle"
                data-sonarr-series-id="{{ series.sonarr_series_id }}"
                {% if series.is_monitored_global %}checked{% endif %}>
-        <label class="form-check-label small" for="monitor-series-{{ series.ratingKey }}">Surveiller Série (Sonarr)</label>
+        <label class="form-check-label small" for="series-monitor-toggle">Surveiller Série (Sonarr)</label>
     </div>
     {% else %}
     <small class="text-warning">Série non trouvée dans Sonarr pour gestion du monitoring global.</small>


### PR DESCRIPTION
This commit updates the series management modal to visually synchronize the monitoring switches in a cascading manner.

- Adds a unique ID and data attributes to the series monitor toggle in the template.
- Replaces the existing JavaScript for the series management modal with a new version that includes the cascading visual synchronization.