### PR TITLE
feat(sonarr): Add multi-part episode forcing option

### DIFF
--- a/app/seedbox_ui/templates/seedbox_ui/_modals.html
+++ b/app/seedbox_ui/templates/seedbox_ui/_modals.html
@@ -195,6 +195,14 @@
                     <input type="number" class="form-control form-control-sm" id="sonarrManualSeasonInput" placeholder="Ex: 1">
                 </div>
 
+                <!-- NOUVELLE CASE À COCHER POUR FORCER LE MODE MULTI-PARTIES -->
+                <div id="sonarrForceMultiPartDiv" class="form-check mb-3" style="display: none;">
+                    <input class="form-check-input" type="checkbox" id="sonarrForceMultiPartCheckbox">
+                    <label class="form-check-label" for="sonarrForceMultiPartCheckbox">
+                        Traiter comme un épisode en plusieurs parties
+                    </label>
+                </div>
+
                 <!-- Section pour les options d'ajout d'une nouvelle série (pour SFTP) -->
                 <div id="sftpSonarrNewSeriesOptionsContainer" class="mt-3 p-3 border rounded" style="display:none;">
                     <h6>Options pour l'ajout de la nouvelle série :</h6>


### PR DESCRIPTION
I've introduced a new feature that allows you to force the system to treat a staged directory as a multi-part episode.

I added a new checkbox, "Traiter comme un épisode en plusieurs parties," to the Sonarr mapping modal. When selected, the backend logic is updated to:
1.  Scan the source directory for all video files.
2.  Sort the files to ensure consistent `partX` numbering.
3.  Rename each video file by appending a `- partX` suffix.
4.  Move all renamed files to the correct season directory.

This addresses the issue where only the first video file in a multi-part episode was being processed.

To implement this, I made changes to:
- `_modals.html`: To add the checkbox.
- `seedbox_ui_modals.js`: To pass the new option to the backend.
- `routes.py`: To implement the file handling logic for multi-part episodes.